### PR TITLE
Add triangulation functionality for indoor tracking and update configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ yarn.lock
 .tago-lock.dev.lock
 .tagoio
 exportBackup
+.tago-lock.prod.lock

--- a/src/services/equipment/tracking/indoor-tracking.ts
+++ b/src/services/equipment/tracking/indoor-tracking.ts
@@ -4,6 +4,7 @@ import { Data, DeviceInfo, TagoContext } from "@tago-io/sdk/lib/types";
 import { parseObjectToTago } from "../../../lib/parse-object-to-tagoio";
 import { verifyGeofenceAlarm } from "../../alerts/verifyGeofenceAlert";
 import { Geofence } from "../../device/is-inside-indoor-geofence";
+import { estimateDevicePosition, Beacon as TriangulationBeacon, DeviceData, TrilaterationOptions } from "./triangulation";
 
 interface Beacon {
   id: string;
@@ -117,33 +118,133 @@ async function getIndoorPos(context: TagoContext, scope: Data[], enviroment: any
 
   const layers_list = await Resources.devices.getDeviceData(siteID, { variables: "layers", qty: 9999 });
   const room_list = await Resources.devices.getDeviceData(siteID, { variables: "beacon_room", qty: 9999 });
+  
+  // Fetch individual triangulation configuration variables
+  const triangulation_variables = await Resources.devices.getDeviceData(siteID, { 
+    variables: [
+      "defaulttxpowerat1m",
+      "defaultpathlossexponent", 
+      "metersperunit",
+      "outputscale",
+      "clamptounitsquare",
+      "minbeaconsfortrilateration",
+      "mindistanceunits"
+    ], 
+    qty: 9999 
+  });
 
-  // Find layer with the most strongest beacon
-  const fixed_position_key = `${siteID}${strongest_beacon.group}`;
-  const layer = layers_list.find((x) => x?.metadata?.fixed_position?.[fixed_position_key]);
-  const room = room_list.find((x) => x.group == strongest_beacon.group);
+  let finalPosition: { x: string; y: string; value: string; color: string; icon: string } | undefined;
+  let layer: Data | undefined;
+  let room: Data | undefined;
 
-  if (!room) {
-    throw console.error("No beacon found in the room!");
+  // Try triangulation first
+  try {
+    const triangulationBeacons: TriangulationBeacon[] = [];
+    
+    // Build beacon positions from layers data
+    for (const layerItem of layers_list) {
+      if (layerItem.metadata?.fixed_position) {
+        const positions = layerItem.metadata.fixed_position;
+        Object.keys(positions).forEach(key => {
+          const beacon = beaconsReceived.find(b => key === `${siteID}${b.group}`);
+          if (beacon) {
+            const position = positions[key];
+            triangulationBeacons.push({
+              id: beacon.id,
+              x: parseFloat(position.x) / 100, // Convert to normalized coordinates
+              y: parseFloat(position.y) / 100,
+              room: 'all' // Use same room for all beacons to enable cross-room triangulation
+            });
+          }
+        });
+      }
+    }
+
+    const deviceData: DeviceData = {
+      beacons: beaconsReceived.map(b => ({ id: b.id, rssi: b.rssi }))
+    };
+
+    // Helper function to get variable value by name
+    const getVariableValue = (varName: string, defaultValue: any) => {
+      const variable = triangulation_variables.find(v => v.variable === varName);
+      return variable?.value !== undefined ? variable.value : defaultValue;
+    };
+
+    // Build triangulation options from individual site variables
+    const triangulationOptions: TrilaterationOptions = {
+      defaultTxPowerAt1m: getVariableValue('defaulttxpowerat1m', -59),
+      defaultPathLossExponent: getVariableValue('defaultpathlossexponent', 2.0),
+      metersPerUnit: getVariableValue('metersperunit', 1),
+      outputScale: getVariableValue('outputscale', 'percent') as 'normalized' | 'percent',
+      clampToUnitSquare: getVariableValue('clamptounitsquare', true),
+      minBeaconsForTrilateration: getVariableValue('minbeaconsfortrilateration', 3),
+      minDistanceUnits: getVariableValue('mindistanceunits', 0.01)
+    };
+
+    console.log("DEBUG triangulationOptions:", triangulationOptions);
+    console.log("DEBUG triangulationBeacons:", triangulationBeacons);
+    console.log("DEBUG deviceData:", deviceData);
+
+    const triangulationResult = estimateDevicePosition(deviceData, triangulationBeacons, triangulationOptions);
+
+    console.log("DEBUG Result:", triangulationResult);
+
+    if (triangulationResult) {
+      // Use triangulation result
+      finalPosition = {
+        x: triangulationResult.x.toString(),
+        y: triangulationResult.y.toString(),
+        value: `Triangulated position`,
+        color: '#4CAF50',
+        icon: 'location'
+      };
+      
+      // Find corresponding layer and room for the triangulated position
+      const usedBeaconId = triangulationResult.usedBeacons[0];
+      const usedBeacon = beaconsReceived.find(b => b.id === usedBeaconId);
+      if (usedBeacon) {
+        const fixed_position_key = `${siteID}${usedBeacon.group}`;
+        layer = layers_list.find((x) => x?.metadata?.fixed_position?.[fixed_position_key]);
+        room = room_list.find((x) => x.group == usedBeacon.group);
+      }
+    }
+  } catch (error) {
+    console.warn("Triangulation failed, falling back to strongest beacon:", error);
   }
 
-  if (!layer) {
-    throw console.error("No beacon found in the layer!");
+  // Fall back to strongest beacon if triangulation failed
+  if (!finalPosition) {
+    const fixed_position_key = `${siteID}${strongest_beacon.group}`;
+    layer = layers_list.find((x) => x?.metadata?.fixed_position?.[fixed_position_key]);
+    room = room_list.find((x) => x.group == strongest_beacon.group);
+
+    if (!room) {
+      throw console.error("No beacon found in the room!");
+    }
+
+    if (!layer) {
+      throw console.error("No beacon found in the layer!");
+    }
+
+    const beaconPosition = layer?.metadata?.fixed_position?.[fixed_position_key];
+
+    if (!beaconPosition) {
+      throw console.error("No beacon found in the layer!");
+    }
+
+    finalPosition = beaconPosition;
   }
 
-  const beaconPosition = layer?.metadata?.fixed_position?.[fixed_position_key];
-
-  if (!beaconPosition) {
-    throw console.error("No beacon found in the layer!");
+  // Ensure we have layer and room data
+  if (!layer || !room) {
+    throw console.error("Could not determine layer or room for position!");
   }
 
   const equipmentInfo = await Resources.devices.info(equipmentID);
-  // const equip_img = equipmentInfo.tags.find((x) => x.key === "equip_img")?.value;
-
   const { name: site_name } = await Resources.devices.info(siteID);
 
-  const assetInfo = getAssetInfoInside(scope, beaconPosition, enviroment, siteID, equipmentInfo, layer, room, site_name);
-  const assetHistory = getAssetHistoryInside(beaconPosition, equipmentInfo, layer, room, site_name);
+  const assetInfo = getAssetInfoInside(scope, finalPosition, enviroment, siteID, equipmentInfo, layer, room, site_name);
+  const assetHistory = getAssetHistoryInside(finalPosition, equipmentInfo, layer, room, site_name);
 
   // remove previous outside location data, add new inside location data
   await Resources.devices.deleteDeviceData(siteID, { variables: ["equipment_outside_location"], groups: equipmentID, qty: 1 });
@@ -166,8 +267,8 @@ async function getIndoorPos(context: TagoContext, scope: Data[], enviroment: any
     siteID,
     {
       deviceID: scope[0].device,
-      pos_x: Number(beaconPosition.x),
-      pos_y: Number(beaconPosition.y),
+      pos_x: Number(finalPosition.x),
+      pos_y: Number(finalPosition.y),
       layerBeacon: layer.group as string,
       geofence_list,
     },

--- a/src/services/equipment/tracking/indoor-tracking.ts
+++ b/src/services/equipment/tracking/indoor-tracking.ts
@@ -130,7 +130,7 @@ async function getIndoorPos(context: TagoContext, scope: Data[], enviroment: any
       "minbeaconsfortrilateration",
       "mindistanceunits"
     ], 
-    qty: 9999 
+    qty: 1 
   });
 
   let finalPosition: { x: string; y: string; value: string; color: string; icon: string } | undefined;
@@ -181,13 +181,7 @@ async function getIndoorPos(context: TagoContext, scope: Data[], enviroment: any
       minDistanceUnits: getVariableValue('mindistanceunits', 0.01)
     };
 
-    console.log("DEBUG triangulationOptions:", triangulationOptions);
-    console.log("DEBUG triangulationBeacons:", triangulationBeacons);
-    console.log("DEBUG deviceData:", deviceData);
-
     const triangulationResult = estimateDevicePosition(deviceData, triangulationBeacons, triangulationOptions);
-
-    console.log("DEBUG Result:", triangulationResult);
 
     if (triangulationResult) {
       // Use triangulation result

--- a/src/services/equipment/tracking/triangulation.ts
+++ b/src/services/equipment/tracking/triangulation.ts
@@ -1,0 +1,310 @@
+/**
+ * estimateDevicePosition — Estimate a device’s 2D position from beacon RSSI.
+ *
+ * Behavior:
+ * - Selects the room of the strongest received beacon (highest RSSI), then discards beacons from other rooms.
+ * - Uses trilateration (least-squares) if ≥3 beacons remain; otherwise falls back to the strongest beacon’s coordinates.
+ * - Optionally clamps the result to the [0..1] map area and can return normalized or percent coordinates.
+ *
+ * Key options:
+ * - defaultTxPowerAt1m: dBm at 1 meter for RSSI→distance (fallback if a beacon lacks txPowerAt1m). Typical ~ -59 dBm.
+ * - defaultPathLossExponent: Environment factor n for path loss (typical indoor 2.0–3.5). Used if a beacon lacks its own n.
+ * - metersPerUnit: How many meters correspond to 1.0 normalized map unit (used to scale RSSI-derived distances).
+ * - outputScale: 'normalized' (0..1) or 'percent' (0..100) for the returned coordinates.
+ * - clampToUnitSquare: If true, clamps (x,y) to [0..1].
+ *
+ * Notes:
+ * - Coordinates for beacons and output are normalized with (0,0) at top-left and (1,1) at bottom-right.
+ * - If trilateration is ill-conditioned (e.g., near-colinear beacons), the function falls back to strongest beacon.
+ */
+
+import { Resources } from "@tago-io/sdk";
+import { site_id } from "../../../analysis/__tests__/mocks/getAssetInfoInside.mock";
+
+// Types and domain models
+export interface Beacon {
+  id: string;
+  x: number; // normalized [0..1]
+  y: number; // normalized [0..1]
+  room: string;
+  // Optional per-beacon calibration
+  txPowerAt1m?: number; // dBm at 1 meter (default -59)
+  pathLossExponent?: number; // environment factor n (default 2.0)
+}
+
+export interface DeviceBeacon {
+  id: string;
+  rssi: number; // e.g., -72
+}
+
+export interface DeviceData {
+  beacons: DeviceBeacon[];
+}
+
+export interface PositionEstimate {
+  x: number; // normalized [0..1] or percent [0..100] depending on outputScale
+  y: number; // normalized [0..1] or percent [0..100]
+  room: string;
+  method: "trilateration" | "fallback-strongest";
+  usedBeacons: string[]; // IDs actually used in the solve
+}
+
+export interface TrilaterationOptions {
+  defaultTxPowerAt1m?: number; // default -59
+  defaultPathLossExponent?: number; // default 2.0 (2.0-3.5 typical indoors)
+  metersPerUnit?: number; // how many meters correspond to 1.0 normalized unit (default 1)
+  outputScale?: "normalized" | "percent"; // default 'normalized'
+  clampToUnitSquare?: boolean; // clamp output to [0,1] range; default true
+  minBeaconsForTrilateration?: number; // default 3
+  minDistanceUnits?: number; // floor distance in normalized units; default 0.01
+}
+
+// Public API
+export function estimateDevicePosition(
+  device: DeviceData,
+  beacons: Beacon[],
+  options: TrilaterationOptions = {}
+): PositionEstimate | null {
+  const {
+    defaultTxPowerAt1m = -59,
+    defaultPathLossExponent = 2.0,
+    metersPerUnit = 1,
+    outputScale = "normalized",
+    clampToUnitSquare = true,
+    minBeaconsForTrilateration = 3,
+    minDistanceUnits = 0.01,
+  } = options;
+
+  const beaconMap = indexBeaconsById(beacons);
+
+  // Keep only device beacons that exist in settings
+  const observed = device.beacons
+    .map((b) => {
+      const meta = beaconMap.get(b.id);
+      return meta ? { ...b, meta } : null;
+    })
+    .filter(Boolean) as Array<DeviceBeacon & { meta: Beacon }>;
+
+  if (observed.length === 0) {
+    return null;
+  }
+
+  // Strongest RSSI determines the room
+  const strongest = observed.reduce((a, b) => (b.rssi > a.rssi ? b : a));
+  const room = strongest.meta.room;
+
+  // Filter to beacons in the same room
+  const observedInRoom = observed.filter((b) => b.meta.room === room);
+  if (observedInRoom.length === 0) {
+    // Shouldn't happen since strongest is in the room, but safe-guard
+    return fallbackToStrongest(strongest, outputScale);
+  }
+
+  // If not enough beacons to triangulate, fallback to strongest beacon's position
+  if (observedInRoom.length < minBeaconsForTrilateration) {
+    return fallbackToStrongest(strongest, outputScale);
+  }
+
+  // Build anchors with distances derived from RSSI
+  const anchors = observedInRoom.map((o) => {
+    const tx = pickNumber(o.meta.txPowerAt1m, defaultTxPowerAt1m);
+    const n = pickNumber(o.meta.pathLossExponent, defaultPathLossExponent);
+    const dMeters = rssiToDistanceMeters(o.rssi, tx, n);
+    const dUnitsRaw = dMeters / metersPerUnit;
+    const dUnits = Math.max(dUnitsRaw, minDistanceUnits); // avoid degeneracies
+    return {
+      id: o.id,
+      x: o.meta.x,
+      y: o.meta.y,
+      d: dUnits,
+      rssi: o.rssi,
+    };
+  });
+
+  // Sort anchors by signal strength (strongest first) to improve numerical stability
+  anchors.sort((a, b) => b.rssi - a.rssi);
+
+  // Solve trilateration using linearized least squares
+  const solve = trilaterateLeastSquares2D(anchors);
+
+  if (!solve) {
+    // Ill-conditioned or failed: spec says fallback to strongest
+    return fallbackToStrongest(strongest, outputScale);
+  }
+
+  const out = maybeClamp(solve, clampToUnitSquare);
+  const scaled = scaleOutput(out, outputScale);
+
+  return {
+    x: scaled.x,
+    y: scaled.y,
+    room,
+    method: "trilateration",
+    usedBeacons: anchors.map((a) => a.id),
+  };
+}
+
+// ---- Implementation details below ----
+
+function indexBeaconsById(beacons: Beacon[]): Map<string, Beacon> {
+  const m = new Map<string, Beacon>();
+  for (const b of beacons) {
+    m.set(b.id, b);
+  }
+  return m;
+}
+
+function pickNumber<T extends number>(...vals: Array<T | undefined>): T {
+  for (const v of vals) {
+    if (typeof v === "number" && Number.isFinite(v)) {
+      return v;
+    }
+  }
+  // @ts-expect-error - at least one numeric default must be provided by callers
+  return undefined;
+}
+
+// RSSI to distance using log-distance path loss model
+// d (meters) = 10 ^ ((TxPowerAt1m - RSSI) / (10 * n))
+function rssiToDistanceMeters(
+  rssi: number,
+  txPowerAt1m: number,
+  pathLossExponent: number
+): number {
+  // Protect against pathological values
+  const n = Math.max(1.0, Math.min(6.0, pathLossExponent));
+  const numerator = txPowerAt1m - sanitizeRssi(rssi);
+  const exp = numerator / (10 * n);
+  const d = Math.pow(10, exp);
+  return isFinite(d) ? d : 1e6;
+}
+
+function sanitizeRssi(rssi: number): number {
+  if (!Number.isFinite(rssi)) return -100;
+  // Typical RSSI range: -20 (very close) to -100 (far)
+  return Math.max(-120, Math.min(-20, rssi));
+}
+
+function fallbackToStrongest(
+  strongest: DeviceBeacon & { meta: Beacon },
+  outputScale: "normalized" | "percent"
+): PositionEstimate {
+  const pos = scaleOutput(
+    { x: strongest.meta.x, y: strongest.meta.y },
+    outputScale
+  );
+  return {
+    x: pos.x,
+    y: pos.y,
+    room: strongest.meta.room,
+    method: "fallback-strongest",
+    usedBeacons: [strongest.id],
+  };
+}
+
+function scaleOutput(
+  p: { x: number; y: number },
+  outputScale: "normalized" | "percent"
+): { x: number; y: number } {
+  if (outputScale === "percent") {
+    return { x: p.x * 100, y: p.y * 100 };
+  }
+  return p;
+}
+
+function maybeClamp(
+  p: { x: number; y: number },
+  clamp: boolean
+): { x: number; y: number } {
+  if (!clamp) return p;
+  return {
+    x: Math.max(0, Math.min(1, p.x)),
+    y: Math.max(0, Math.min(1, p.y)),
+  };
+}
+
+// Linearized least squares trilateration in 2D.
+// For anchors (xi, yi, di), use first anchor as reference and solve:
+// 2(xi - x1) * x + 2(yi - y1) * y = (xi^2 - x1^2 + yi^2 - y1^2) + d1^2 - di^2  for i=2..n
+function trilaterateLeastSquares2D(
+  anchors: Array<{ id: string; x: number; y: number; d: number }>
+): { x: number; y: number } | null {
+  if (anchors.length < 3) {
+    return null;
+  }
+
+  const ref = anchors[0];
+  // Build normal equations ATA * [x;y] = ATb (ATA is 2x2, ATb is 2x1)
+  let ata11 = 0,
+    ata12 = 0,
+    ata22 = 0;
+  let atb1 = 0,
+    atb2 = 0;
+
+  for (let i = 1; i < anchors.length; i++) {
+    const ai = anchors[i];
+    const A0 = 2 * (ai.x - ref.x);
+    const A1 = 2 * (ai.y - ref.y);
+    const bi =
+      ai.x * ai.x -
+      ref.x * ref.x +
+      (ai.y * ai.y - ref.y * ref.y) +
+      (ref.d * ref.d - ai.d * ai.d);
+
+    // Accumulate ATA
+    ata11 += A0 * A0;
+    ata12 += A0 * A1;
+    ata22 += A1 * A1;
+
+    // Accumulate ATb
+    atb1 += A0 * bi;
+    atb2 += A1 * bi;
+  }
+
+  const det = ata11 * ata22 - ata12 * ata12;
+  const EPS = 1e-12;
+
+  if (Math.abs(det) < EPS) {
+    // Ill-conditioned (e.g., near-colinear anchor layout)
+    return null;
+  }
+
+  // Inverse of 2x2 [a b; b c] is (1/det) * [c -b; -b a]
+  const inv11 = ata22 / det;
+  const inv12 = -ata12 / det;
+  const inv22 = ata11 / det;
+
+  const x = inv11 * atb1 + inv12 * atb2;
+  const y = inv12 * atb1 + inv22 * atb2;
+
+  if (!isFinite(x) || !isFinite(y)) {
+    return null;
+  }
+
+  return { x, y };
+}
+
+// ------------------- Example usage -------------------
+// Uncomment to test locally
+// const beacons: Beacon[] = [
+//   { id: '5b8ce8', x: 0.87, y: 0.11, room: 'A' },
+//   { id: '5b8cf4', x: 0.74, y: 0.81, room: 'A' },
+//   { id: '5b8cf1', x: 0.15, y: 0.14, room: 'A' },
+//   { id: '5b8cf3', x: 0.1, y: 0.5, room: 'A' },
+// ];
+
+// const device: DeviceData = {
+//   beacons: [
+//     { id: '5b8ce8', rssi: -64 },
+//     { id: '5b8cf4', rssi: -78 },
+//     { id: '5b8cf1', rssi: -72 },
+//   ],
+// };
+
+// const pos = estimateDevicePosition(device, beacons, {
+//   defaultTxPowerAt1m: -59,
+//   defaultPathLossExponent: 2.2,
+//   metersPerUnit: 10,           // if 1.0 normalized unit ~= 10 meters across your map
+//   outputScale: 'normalized',
+//   clampToUnitSquare: true,
+// });

--- a/tagoconfig.json
+++ b/tagoconfig.json
@@ -2,7 +2,7 @@
     "$schema": "https://github.com/tago-io/tagoio-cli/blob/master/docs/schema.json",
     "analysisPath": "./src/analysis",
     "buildPath": "./build",
-    "dev": {
+    "prod": {
         "analysisList": [
             {
                 "fileName": "alert-retry.ts",
@@ -18,11 +18,6 @@
                 "fileName": "analysisAssetTracking.ts",
                 "name": "[TagoIO] - Asset Tracking",
                 "id": "5fe0fad942fbde001f84752a"
-            },
-            {
-                "fileName": "",
-                "name": "[TagoIO] - Device Emulator",
-                "id": "64023f09c0e31d0008fbc63b"
             },
             {
                 "fileName": "analysisDeviceUpdater.ts",
@@ -42,6 +37,43 @@
         ],
         "id": "5fc13907cf4e170027440a96",
         "profileName": "RTLS/Marker Kickstarter",
+        "email": "freddy.minuzzi@tago.io"
+    },
+    "dev": {
+        "analysisList": [
+            {
+                "fileName": "alert-retry.ts",
+                "name": "[TagoIO] - Alert Retry",
+                "id": "68a72c366c048d00095a899f"
+            },
+            {
+                "fileName": "alert-trigger.ts",
+                "name": "[TagoIO] - Alert Trigger",
+                "id": "68a72c34e99e4900097e1fce"
+            },
+            {
+                "fileName": "analysisAssetTracking.ts",
+                "name": "[TagoIO] - Asset Tracking",
+                "id": "68a72c32e99e4900097e1f6b"
+            },
+            {
+                "fileName": "analysisDeviceUpdater.ts",
+                "name": "[TagoIO] - Device Updater",
+                "id": "68a72c2f91d98a000bc3d6d4"
+            },
+            {
+                "fileName": "geofenceAlertTrigger.ts",
+                "name": "[TagoIO] - GeofenceAlertTrigger",
+                "id": "68a72c2dbe6b3c000ad273f2"
+            },
+            {
+                "fileName": "analysisHandler.ts",
+                "name": "[TagoIO] - Handler",
+                "id": "68a72c2be99e4900097e1ef5"
+            }
+        ],
+        "id": "68a72bae4f02a9000a41bdbb",
+        "profileName": "RTLS - Triangulation QA",
         "email": "freddy.minuzzi@tago.io"
     }
 }


### PR DESCRIPTION
Added triangulation into the RTLS kickstarter, if triangulation requisites are not met the system will revert to the highest signaling RSSI method instead. 

In the Site Dashboard, at the Floor and Beacon Setup widget users can now setup necessary triangulation settings.

Jira card: https://tago-io.atlassian.net/browse/PE-133